### PR TITLE
[BE] Rate Limit 수정 및 히스토리 소프트 딜리트

### DIFF
--- a/BE/catching/src/main/java/com/dongledungle/catching/analysis/controller/AnalysisController.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/analysis/controller/AnalysisController.java
@@ -10,6 +10,7 @@ import com.dongledungle.catching.analysis.service.GeminiService;
 import com.dongledungle.catching.analysis.service.RateLimitService;
 import com.dongledungle.catching.analysis.service.UrlResolverService;
 import com.dongledungle.catching.auth.entity.User;
+import com.dongledungle.catching.analysis.exception.RateLimitExceededException;
 import com.dongledungle.catching.analysis.exception.SafetyBlockedException;
 import com.dongledungle.catching.common.response.ApiResponse;
 import com.dongledungle.catching.common.util.JsonParserUtil;
@@ -32,6 +33,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -56,8 +58,15 @@ public class AnalysisController {
 
     @PostMapping(value = "/json", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter analyzeJson(Authentication authentication, @RequestBody AnalysisRequestDto request) {
-        SseEmitter emitter = new SseEmitter(600000L);
         Long userId = Long.parseLong((String) authentication.getPrincipal());
+        
+        // Rate limit 체크
+        if (!rateLimitService.isUserAllowed(userId)) {
+            Long remainingTime = rateLimitService.getRemainingTime(userId);
+            throw new RateLimitExceededException(remainingTime + "초 후에 다시 시도해주세요.", remainingTime);
+        }
+
+        SseEmitter emitter = new SseEmitter(600000L);
         request.setUserId(userId);
         CompletableFuture.runAsync(() -> processAnalysisWithSSE(request, emitter, true));
         return emitter;
@@ -66,22 +75,35 @@ public class AnalysisController {
     @PostMapping(value = "/text", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter analyzeText(Authentication authentication, @Valid @RequestBody AnalysisRequestDto request) {
         Long userId = Long.parseLong((String) authentication.getPrincipal());
-        SseEmitter emitter = new SseEmitter(600000L);
 
         // Rate limit 체크
         if (!rateLimitService.isUserAllowed(userId)) {
             Long remainingTime = rateLimitService.getRemainingTime(userId);
-            sendSseEvent(emitter, "error",
-                    gson.toJson(new ErrorResponse("RATE_LIMIT",
-                            remainingTime + "초 후에 다시 시도해주세요.")));
-            emitter.complete();
-            return emitter;
+            throw new RateLimitExceededException(remainingTime + "초 후에 다시 시도해주세요.", remainingTime);
         }
 
-
+        SseEmitter emitter = new SseEmitter(600000L);
         request.setUserId(userId);
         CompletableFuture.runAsync(() -> processAnalysisWithSSE(request, emitter, false));
         return emitter;
+    }
+
+    @GetMapping("/check-rate-limit")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> checkRateLimit(Authentication authentication) {
+        Long userId = Long.parseLong((String) authentication.getPrincipal());
+        Long remainingTime = rateLimitService.getRemainingTime(userId);
+
+        if (remainingTime > 0) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(
+                    ApiResponse.error(
+                            HttpStatus.TOO_MANY_REQUESTS.value(),
+                            remainingTime + "초 후에 다시 시도해주세요.",
+                            Map.of("isAllowed", false, "remainingTime", remainingTime)
+                    )
+            );
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(Map.of("isAllowed", true)));
     }
 
     @GetMapping("/{analysisId}")
@@ -166,6 +188,16 @@ public class AnalysisController {
 
         } catch (Exception e) {
             log.error("SSE 처리 중 예외 발생", e);
+            String errorType = determineErrorType(e);
+            
+            rateLimitService.unmarkAsProcessing(request.getUserId(), request.getCompany(), request.getPosition());
+            if (!"SAFETY_BLOCKED".equals(errorType)) {
+                rateLimitService.resetUserCooldown(request.getUserId());
+                log.debug("일반 에러: 사용자 {} 쿨다운 해제", request.getUserId());
+            } else {
+                log.warn("안전 정책 위반: 사용자 {} 1분 페널티 유지", request.getUserId());
+            }
+
             handleSseError(emitter, e);
         }
     }
@@ -207,7 +239,7 @@ public class AnalysisController {
             sendSseEvent(emitter, "complete", "success");
             emitter.complete();
 
-        }, emitter);
+        }, emitter, request);
     }
 
     // ============ AI 스트리밍 (Text - 병렬 처리) ============
@@ -258,6 +290,15 @@ public class AnalysisController {
         } catch (Exception e) {
             log.error("AI 분석 최종 실패", e);
             String errorType = determineErrorType(e);
+            
+            rateLimitService.unmarkAsProcessing(request.getUserId(), request.getCompany(), request.getPosition());
+            if (!"SAFETY_BLOCKED".equals(errorType)) {
+                rateLimitService.resetUserCooldown(request.getUserId());
+                log.debug("일반 에러: 사용자 {} 쿨다운 해제", request.getUserId());
+            } else {
+                log.warn("안전 정책 위반: 사용자 {} 1분 페널티 유지", request.getUserId());
+            }
+
             String errorMessage = getUserFriendlyMessage(errorType);
             sendSseEvent(emitter, "error", gson.toJson(new ErrorResponse(errorType, errorMessage)));
             emitter.completeWithError(e);
@@ -364,7 +405,7 @@ public class AnalysisController {
         throw lastException != null ? lastException : new RuntimeException("AI 분석 실패");
     }
 
-    private void retryWithLimit(Runnable task, SseEmitter emitter) {
+    private void retryWithLimit(Runnable task, SseEmitter emitter, AnalysisRequestDto request) {
         for (int attempt = 1; attempt <= MAX_AUTO_RETRIES; attempt++) {
             try {
                 if (attempt > 1) {
@@ -378,9 +419,13 @@ public class AnalysisController {
                 return;
 
             } catch (Exception e) {
+                String errorType = determineErrorType(e);
+
                 if (e instanceof SafetyBlockedException) {
                     log.warn("AI 분석 차단됨 (Safety Policy): {}", e.getMessage());
-                    String errorType = determineErrorType(e);
+                    rateLimitService.unmarkAsProcessing(request.getUserId(), request.getCompany(), request.getPosition());
+                    log.warn("안전 정책 위반: 사용자 {} 1분 페널티 유지", request.getUserId());
+                    
                     String errorMessage = getUserFriendlyMessage(errorType);
                     sendSseEvent(emitter, "error", gson.toJson(new ErrorResponse(errorType, errorMessage)));
                     emitter.completeWithError(e);
@@ -389,7 +434,14 @@ public class AnalysisController {
                 log.error("AI 분석 실패 (시도 {}/{}): {}", attempt, MAX_AUTO_RETRIES, e.getMessage());
 
                 if (attempt >= MAX_AUTO_RETRIES) {
-                    String errorType = determineErrorType(e);
+                    rateLimitService.unmarkAsProcessing(request.getUserId(), request.getCompany(), request.getPosition());
+                    if (!"SAFETY_BLOCKED".equals(errorType)) {
+                        rateLimitService.resetUserCooldown(request.getUserId());
+                        log.debug("일반 에러: 사용자 {} 쿨다운 해제", request.getUserId());
+                    } else {
+                        log.warn("안전 정책 위반: 사용자 {} 1분 페널티 유지", request.getUserId());
+                    }
+
                     String errorMessage = getUserFriendlyMessage(errorType);
                     sendSseEvent(emitter, "error", gson.toJson(new ErrorResponse(errorType, errorMessage)));
                     emitter.completeWithError(e);
@@ -431,7 +483,15 @@ public class AnalysisController {
                 }
             }
         }
-        return fullResponse.toString();
+
+        String result = fullResponse.toString();
+        
+        // 커스텀 가드레일 문구(악의적 프롬프트) 감지 시 Safety 정책 위반으로 간주하여 강제 차단
+        if (result.contains("분석 목적에 맞지 않는 내용이 포함되어 있어 분석을 수행할 수 없습니다")) {
+            throw new SafetyBlockedException("커스텀 가드레일에 의해 악의적 프롬프트로 차단되었습니다.");
+        }
+        
+        return result;
     }
 
     /**

--- a/BE/catching/src/main/java/com/dongledungle/catching/analysis/controller/AnalysisController.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/analysis/controller/AnalysisController.java
@@ -56,7 +56,7 @@ public class AnalysisController {
     private static final int MAX_AUTO_RETRIES = 2;
     private static final long RETRY_DELAY_MS = 1000;
 
-    @PostMapping(value = "/json", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PostMapping(value = "/json", produces = {MediaType.TEXT_EVENT_STREAM_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public SseEmitter analyzeJson(Authentication authentication, @RequestBody AnalysisRequestDto request) {
         Long userId = Long.parseLong((String) authentication.getPrincipal());
         
@@ -72,7 +72,7 @@ public class AnalysisController {
         return emitter;
     }
 
-    @PostMapping(value = "/text", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PostMapping(value = "/text", produces = {MediaType.TEXT_EVENT_STREAM_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public SseEmitter analyzeText(Authentication authentication, @Valid @RequestBody AnalysisRequestDto request) {
         Long userId = Long.parseLong((String) authentication.getPrincipal());
 
@@ -88,7 +88,7 @@ public class AnalysisController {
         return emitter;
     }
 
-    @GetMapping("/check-rate-limit")
+    @GetMapping("/check")
     public ResponseEntity<ApiResponse<Map<String, Object>>> checkRateLimit(Authentication authentication) {
         Long userId = Long.parseLong((String) authentication.getPrincipal());
         Long remainingTime = rateLimitService.getRemainingTime(userId);

--- a/BE/catching/src/main/java/com/dongledungle/catching/analysis/exception/RateLimitExceededException.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/analysis/exception/RateLimitExceededException.java
@@ -1,0 +1,14 @@
+package com.dongledungle.catching.analysis.exception;
+
+public class RateLimitExceededException extends RuntimeException {
+    private final Long remainingTime;
+
+    public RateLimitExceededException(String message, Long remainingTime) {
+        super(message);
+        this.remainingTime = remainingTime;
+    }
+
+    public Long getRemainingTime() {
+        return remainingTime;
+    }
+}

--- a/BE/catching/src/main/java/com/dongledungle/catching/analysis/service/RateLimitService.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/analysis/service/RateLimitService.java
@@ -20,7 +20,7 @@ public class RateLimitService {
     // 분석 진행 중 상태 (userId:company:position -> 시작 시간)
     private final Map<String, Instant> processingAnalysis = new ConcurrentHashMap<>();
 
-    private static final long COOLDOWN_SECONDS = 60; // 1분 제한
+    private static final long COOLDOWN_SECONDS = 50; // 50초 제한
     private static final long PROCESSING_TIMEOUT_MINUTES = 10; // 처리 중 타임아웃
 
     private final ScheduledExecutorService cleanupScheduler;

--- a/BE/catching/src/main/java/com/dongledungle/catching/analysis/service/UrlResolverService.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/analysis/service/UrlResolverService.java
@@ -18,7 +18,7 @@ public class UrlResolverService  {
 
     // URL 패턴: 마크다운 링크 또는 단독 URL
     private static final Pattern URL_PATTERN = Pattern.compile(
-            "(https://vertexaisearch\\.cloud\\.google\\.com/grounding-api-redirect/[^\\s)\\]]+)"
+            "(https://vertexaisearch\\.cloud\\.google\\.com/grounding-api-redirect/[a-zA-Z0-9_\\-~=]+)"
     );
 
     /**
@@ -30,8 +30,11 @@ public class UrlResolverService  {
             return url;
         }
 
+        // 마지막에 묻어올 수 있는 문자 제거
+        String cleanUrl = url.replaceAll("[\"'\\]),.]+$", "").trim();
+
         try {
-            HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            HttpURLConnection connection = (HttpURLConnection) URI.create(cleanUrl).toURL().openConnection();
             connection.setRequestMethod("GET");
             connection.setInstanceFollowRedirects(false);  // 자동 리다이렉트 비활성화
             connection.setConnectTimeout(5000);
@@ -40,41 +43,41 @@ public class UrlResolverService  {
 
             int responseCode = connection.getResponseCode();
 
-            if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP ||    // 302
-                    responseCode == HttpURLConnection.HTTP_MOVED_PERM ||    // 301
-                    responseCode == HttpURLConnection.HTTP_SEE_OTHER) {     // 303
+            if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP || // 302
+                responseCode == HttpURLConnection.HTTP_MOVED_PERM || // 301
+                responseCode == HttpURLConnection.HTTP_SEE_OTHER) {  // 303
 
                 // 먼저 헤더에서 추출 시도
                 String location = connection.getHeaderField("Location");
                 if (location != null && !location.isEmpty()) {
-                    log.debug("URL resolved: {} -> {}", url, location);
+                    log.debug("URL resolved: {} -> {}", cleanUrl, location);
                     return location;
                 }
 
                 // 실패했을 경우 받은 HTML 본문 파싱
                 try (BufferedReader in = new BufferedReader(
                         new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
-
+                    
                     String line;
-                    // 대소문자 구분 없이 <a href="...">를 찾는 정규식
-                    Pattern linkPattern = Pattern.compile("(?i)<a\\s+href=\"([^\"]+)\"");
-
+                    Pattern linkPattern = Pattern.compile("(?i)<a[^>]+href=[\"']([^\"']+)[\"']");
                     while ((line = in.readLine()) != null) {
-                        Matcher linkMatcher = linkPattern.matcher(line);
-                        if (linkMatcher.find()) {
-                            String extractedUrl = linkMatcher.group(1);
-                            log.debug("URL resolved via HTML Body: {} -> {}", url, extractedUrl);
+                        Matcher m = linkPattern.matcher(line);
+                        if (m.find()) {
+                            String extractedUrl = m.group(1);
+                            log.debug("URL resolved from body: {} -> {}", cleanUrl, extractedUrl);
                             return extractedUrl;
                         }
                     }
                 }
+            } else {
+                log.warn("URL 변환 실패 (응답 코드: {}), 원본 유지: {}", responseCode, cleanUrl);
             }
-
             connection.disconnect();
+            
         } catch (Exception e) {
-            log.warn("URL 변환 실패, 원본 유지: {} - {}", url, e.getMessage());
+            log.warn("URL 변환 실패, 원본 유지: {} - {}", cleanUrl, e.getMessage());
         }
-
+        
         return url;  // 실패 시 원본 반환
     }
 

--- a/BE/catching/src/main/java/com/dongledungle/catching/common/exception/GlobalExceptionHandler.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.dongledungle.catching.analysis.exception.RateLimitExceededException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     /**
@@ -33,6 +35,19 @@ public class GlobalExceptionHandler {
                         HttpStatus.BAD_REQUEST.value(),
                         "입력값이 올바르지 않습니다.",
                         errors
+                ));
+    }
+
+    /**
+     * Rate Limit 제한에 걸렸을 때 발생하는 예외 (429 Too Many Requests)
+     */
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> handleRateLimitExceeded(RateLimitExceededException ex) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .body(ApiResponse.error(
+                        HttpStatus.TOO_MANY_REQUESTS.value(),
+                        ex.getMessage(),
+                        Map.of("remainingTime", ex.getRemainingTime())
                 ));
     }
 }

--- a/BE/catching/src/main/java/com/dongledungle/catching/history/controller/HistoryController.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/history/controller/HistoryController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +27,12 @@ public class HistoryController {
         return ResponseEntity.ok(
                 ApiResponse.success("유저의 최근 한 달 History", history)
         );
+    }
+
+    @DeleteMapping("/{historyId}")
+    public ResponseEntity<ApiResponse<Void>> deleteHistory(Authentication authentication, @PathVariable Long historyId) {
+        long userId = Long.parseLong((String) authentication.getPrincipal());
+        historyService.deleteHistory(userId, historyId);
+        return ResponseEntity.ok(ApiResponse.success("히스토리가 성공적으로 삭제되었습니다."));
     }
 }

--- a/BE/catching/src/main/java/com/dongledungle/catching/history/entity/History.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/history/entity/History.java
@@ -33,6 +33,14 @@ public class History {
     @Column(name="year_month_week", nullable = false)
     private String yearMonthWeek; //"2025-11-W3" (2025년 11월 3주차)
 
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "boolean default false")
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    public void markAsDeleted() {
+        this.isDeleted = true;
+    }
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_position_id", insertable = false, updatable = false)
     private Analysis analysis;

--- a/BE/catching/src/main/java/com/dongledungle/catching/history/repository/HistoryRepository.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/history/repository/HistoryRepository.java
@@ -41,6 +41,7 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
                 JOIN analysis a ON h.companyPositionId = a.companyPositionId
             WHERE h.userId = :userId
                 AND h.createdAt >= :oneMonthAgo
+                AND h.isDeleted = false
             ORDER BY h.createdAt DESC
             """
     )

--- a/BE/catching/src/main/java/com/dongledungle/catching/history/service/HistoryService.java
+++ b/BE/catching/src/main/java/com/dongledungle/catching/history/service/HistoryService.java
@@ -56,4 +56,20 @@ public class HistoryService {
         log.info("History 저장: userId={}, companyPositionId={}, week={}",
                 userId, companyPositionId, currentMonthWeek);
     }
+
+    /**
+     * 히스토리 소프트 딜리트
+     */
+    @Transactional
+    public void deleteHistory(Long userId, Long historyId) {
+        History history = historyRepository.findById(historyId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 히스토리입니다."));
+
+        if (!history.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인의 히스토리만 삭제할 수 있습니다.");
+        }
+
+        history.markAsDeleted();
+        log.info("History 소프트 삭제 처리: historyId={}, userId={}", historyId, userId);
+    }
 }


### PR DESCRIPTION
이 PR은 백엔드의 **요청 제한(Rate Limit), 예외 처리, URL 변환, 사용자 기록 관리**를 개선합니다.

**주요 변경 사항:**

1. **요청 제한 및 에러 처리 개선**
   - 전역 예외 처리(`RateLimitExceededException`)를 도입해 429 에러(남은 대기 시간 포함)를 반환
   - 클라이언트가 Rate Limit 상태를 확인할 수 있는 `/check` 엔드포인트 추가

2. **AI 분석 및 안전 정책(Guardrail) 처리**
   - 일반 오류 발생 시엔 사용자의 대기 시간을 초기화하고, AI 안전 정책 위반이 감지되면 대기시간 유지

3. **URL 변환(리다이렉트) 안정성 강화**
   - URL 패턴 정규식을 개선하고, 끝에 붙은 문장 부호 등을 제거하여 파싱 오류 방지

4. **히스토리 소프트 삭제 추가**